### PR TITLE
Two chrome compatability changes

### DIFF
--- a/js/client.ts
+++ b/js/client.ts
@@ -155,7 +155,7 @@ function getElementIndex(el: any): number {
 function getElementPath(el: Element): number[] {
   const path = [];
 
-  while (el !== document.documentElement) {
+  while (el !== document.body) {
     path.unshift(getElementIndex(el));
     el = (el as any).parentElement;
   }
@@ -392,7 +392,7 @@ function connect() {
   const port = window.location.port ? window.location.port : (window.location.protocol === 'http' ? 80 : 443);
   const ws = new WebSocket("ws://" + window.location.hostname + ":" + port);
 
-  document.documentElement.appendChild(root);
+  document.body.appendChild(root);
 
   ws.onmessage = (event) => {
     const update: Update = JSON.parse(event.data);
@@ -400,9 +400,9 @@ function connect() {
     switch (update.type) {
       case 'replace':
         if (root !== null) {
-          document.documentElement.removeChild(root);
+          document.body.removeChild(root);
           root = document.createElement('div');
-          document.documentElement.appendChild(root);
+          document.body.appendChild(root);
         }
 
         for (const element of update.dom) {

--- a/js/dist/client.js
+++ b/js/dist/client.js
@@ -71,7 +71,7 @@ function getElementIndex(el) {
 }
 function getElementPath(el) {
     const path = [];
-    while (el !== document.documentElement) {
+    while (el !== document.body) {
         path.unshift(getElementIndex(el));
         el = el.parentElement;
     }
@@ -261,15 +261,15 @@ function connect() {
     let root = document.createElement('div');
     const port = window.location.port ? window.location.port : (window.location.protocol === 'http' ? 80 : 443);
     const ws = new WebSocket("ws://" + window.location.hostname + ":" + port);
-    document.documentElement.appendChild(root);
+    document.body.appendChild(root);
     ws.onmessage = (event) => {
         const update = JSON.parse(event.data);
         switch (update.type) {
             case 'replace':
                 if (root !== null) {
-                    document.documentElement.removeChild(root);
+                    document.body.removeChild(root);
                     root = document.createElement('div');
-                    document.documentElement.appendChild(root);
+                    document.body.appendChild(root);
                 }
                 for (const element of update.dom) {
                     buildDOM(ws, element, null, root);

--- a/src/Network/Wai/Handler/Replica.hs
+++ b/src/Network/Wai/Handler/Replica.hs
@@ -67,7 +67,7 @@ app title options initial step
     indexBS = BL.fromStrict $ V.index title
 
     backupApp :: Application
-    backupApp _ respond = respond $ responseLBS status200 [] indexBS
+    backupApp _ respond = respond $ responseLBS status200 [("content-type", "text/html")] indexBS
 
 websocketApp :: forall st.
      st


### PR DESCRIPTION
This fixes two small issues I had running the examples using chrome (linux 75.0.3770.90)

1. Without a `content-type` of `text-html` chrome renders index.html as text
1. Using `document.documentElement`  make chrome render the content below the <body> element at the bottom of the browser window. Using `document.body` fixes this