### PR TITLE
[WIP] Toward SSR/re-connecting

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -33,6 +33,7 @@ dependencies:
 - wai
 - websockets
 - wai-websockets
+- async
 
 library:
   source-dirs: src

--- a/replica.cabal
+++ b/replica.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.1.
+-- This file has been generated from package.yaml by hpack version 0.31.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 934c3c818dc54dc66c2f0d09adbc567a3dfdf1eb37bee17e74f6c89b5d672e8c
+-- hash: 215aed795510b74ab2d18cbd84ecdaded37ec8aef43c5b2b63551fa8893b3c72
 
 name:           replica
 version:        0.1.0.0
@@ -42,6 +42,7 @@ library
   build-depends:
       Diff
     , aeson
+    , async
     , base >=4.7 && <5
     , bytestring
     , containers
@@ -67,6 +68,7 @@ test-suite replica-test
       Diff
     , QuickCheck
     , aeson
+    , async
     , base >=4.7 && <5
     , bytestring
     , containers

--- a/src/Network/Wai/Handler/Replica.hs
+++ b/src/Network/Wai/Handler/Replica.hs
@@ -109,11 +109,12 @@ websocketApp initial step pendingConn = do
     -- change
     --
     --    * We should distinguish *frame* and *frame ID*.
-    --    * special treat the *first step*. We'll need to do this for SSR(server-side rendering)
+    --    * Excluding the *first step* from loop. We'll need to do this for SSR(server-side rendering)
     --    * Two thread commnicating throw two tvar, its kinad hard to reason about and making
     --      it hard to understand the flow.
     --      We only need concurency while `running` function (2) part, so changed only that
     --      part runs concurrently.
+    --    * changed the loop to make showing the vdom first. I think this is more easy to reason.
     --
     -- minor changes
     --
@@ -135,11 +136,13 @@ websocketApp initial step pendingConn = do
     -- 2) 次の一歩を進める。
     -- This is the most hard part.
     --
-    -- 3). If its not over yet, prepare for the next loop.
+    -- 3). If its not over yet, prepare for the next step.
     --
     --  * clientFrameId means, ...<TODO>
     --
     -- TODO: name `update` doesn't fit..
+    -- TODO: Pair of V.HTML and (Event -> IO ()) is 不可分。maybe define a type for it?
+    -- TODO: Frame { frameId :: Int, html :: V.HTML, fire :: (Event -> IO ()) } が正しい気がしてきた。
     running :: Connection -> Update -> V.HTML -> st -> (Event -> IO ()) -> Int -> IO ()
     running conn update vdom st fire frameId = do
       sendTextData conn $ A.encode $ update                 -- (1)

--- a/src/Network/Wai/Handler/Replica.hs
+++ b/src/Network/Wai/Handler/Replica.hs
@@ -166,7 +166,7 @@ attachContextToWebsocket conn ctx = withWorker eventLoop frameLoop
       e <- atomically $  Left <$> getNewerFrame <|> Right <$> waitCatchSTM (ctxThread ctx)
       case e of
         Left (v@(frame,_), stepedBy) -> do
-          diff <- evaluate $ V.diff (frameVdom frame) (frameVdom prevFrame)
+          diff <- evaluate $ V.diff (frameVdom prevFrame) (frameVdom frame)
           let updateDom = UpdateDOM (frameNumber frame) (evtClientFrame <$> stepedBy) diff
           sendTextData conn $ A.encode $ updateDom
           frameLoop' v

--- a/src/Network/Wai/Handler/Replica.hs
+++ b/src/Network/Wai/Handler/Replica.hs
@@ -3,8 +3,11 @@
 
 module Network.Wai.Handler.Replica where
 
-import           Control.Concurrent.Async       (withAsync, link)
-import           Control.Concurrent.STM
+import           Control.Concurrent.Async       (Async, async, withAsync, waitCatchSTM, link, race)
+import           Control.Concurrent.STM         (TMVar, TQueue, TVar, STM, atomically, retry, check, throwSTM
+                                                , newTVar, readTVar, writeTVar
+                                                , newTMVar, newEmptyTMVar, tryPutTMVar, readTMVar, isEmptyTMVar
+                                                , newTQueue, writeTQueue, readTQueue)
 import           Control.Monad                  (join, void, forever)
 import           Control.Applicative            ((<|>))
 import           Control.Exception              (SomeException(SomeException),Exception, throwIO, evaluate, try)
@@ -18,7 +21,7 @@ import qualified Data.Text.Encoding             as TE
 import qualified Data.Text.Lazy                 as TL
 import qualified Data.Text.Lazy.Builder         as TB
 import           Data.Bool                      (bool)
-import           Data.Void                      (Void)
+import           Data.Void                      (Void, absurd)
 import           Data.IORef                     (newIORef, readIORef, writeIORef)
 import           Network.HTTP.Types             (status200)
 
@@ -86,14 +89,16 @@ websocketApp initial step pendingConn = do
     s <- firstStep initial step
     case s of
       Nothing ->
-        pure ()
-      Just (_initialFrame, runner) ->
-        -- `initialFrame` can be used for SSR(server-side rendering). We aren't using it yet,
+        pure Nothing
+      Just (_initialVdom, startContext') -> do
+        -- `initialVdom` can be used for SSR(server-side rendering). We aren't using it yet,
         -- so its prefixed by underscore `_`.
-        runner conn
+        ctx <- startContext'
+        attachContextToWebsocket conn ctx
   case r of
-    Left (SomeException e) -> sendCloseCode conn closeCodeInternalError (T.pack $ show e)
-    Right _                -> sendClose conn ("done" :: T.Text)
+    Left (SomeException e)         -> sendCloseCode conn closeCodeInternalError (T.pack $ show e)
+    Right (Just (SomeException e)) -> sendCloseCode conn closeCodeInternalError (T.pack $ show e)
+    Right _                        -> sendClose conn ("done" :: T.Text)
   where
     closeCodeInternalError = 1011
 
@@ -133,7 +138,7 @@ data Frame = Frame
 firstStep
   :: st
   -> (st -> IO (Maybe (V.HTML, st, Event -> Maybe (IO ()))))
-  -> IO (Maybe (Frame, Connection -> IO ()))
+  -> IO (Maybe (V.HTML, IO Context))
 firstStep initial step = do
   r <- step initial
   case r of
@@ -141,8 +146,7 @@ firstStep initial step = do
       pure Nothing
     Just (_vdom, st, fire) -> do
       vdom <- evaluate _vdom
-      let frame = Frame 1 vdom fire
-      pure $ Just (frame, \conn -> running conn step (ReplaceDOM vdom) st frame)
+      pure $ Just (vdom, startContext step (vdom, st, fire))
 
 -- | Running loop
 --
@@ -189,6 +193,111 @@ running conn step update st frame = do
     let newUpdate = UpdateDOM (frameNumber frame + 1) (evtClientFrame <$> firedEv) diff
     let newFrame = Frame (frameNumber frame + 1) newVdom newFire
     running conn step newUpdate newSt newFrame
+  where
+    -- Like `withAsync`, but it also stops the second action when
+    -- first actions ends with exception.
+    withAsync' :: IO () -> IO a -> IO a
+    withAsync' w m = withAsync w (\a -> link a *> m)
+
+    whenJust_ :: Applicative m => Maybe a -> (a -> m ()) -> m ()
+    whenJust_ m f = void $ traverse f m
+
+-- | Attacehes context to webcoket connection and start
+--
+-- This function will block until:
+--
+--   1) Connection/Protocol-wise exception thrown
+--   2) Context ends gracefully, returning `Nothing`
+--   3) Context ends by exception, returning `Just SomeException`
+--
+-- Some notes:
+--
+--   * Assumes this context is not attached to any other connection.
+--   * Connection/Protocol-wise exception(e.g. connection closed by client) will not stop the context.
+--   * Atleast one frame will always be sent immiedatly. Even in a case where context is already
+--     over/stopped by exception. In those case, it sends one frame and immiedeatly returns.
+--   * First frame will be sent as `ReplaceDOM`, following frame will be sent as `UpdateDOM`
+--   * In some rare case, when stepLoop is looping too fast, few frame might be get skipped,
+--     but its not much a problems since those frame would have been shown only for a moment.
+--
+-- Yeah, this framework is probably not meant for showing smooth animation.
+-- We can actually mitigate this by preserving recent frames, not just the latest one.
+--
+attachContextToWebsocket :: Connection -> Context -> IO (Maybe SomeException)
+attachContextToWebsocket conn ctx = withWorker eventLoop frameLoop
+  where
+    frameLoop :: IO (Maybe SomeException)
+    frameLoop = do
+      v@(f, _) <- atomically $ readTVar (ctxFrame ctx)
+      sendTextData conn $ A.encode $ ReplaceDOM (frameVdom f)
+      frameLoop' v
+
+    frameLoop' :: (Frame, TMVar (Maybe Event)) -> IO (Maybe SomeException)
+    frameLoop' (prevFrame, prevStepedBy) = do
+      e <- atomically $  Left <$> getNewerFrame <|> Right <$> waitCatchSTM (ctxThread ctx)
+      case e of
+        Left (v@(frame,_), stepedBy) -> do
+          diff <- evaluate $ V.diff (frameVdom frame) (frameVdom prevFrame)
+          let updateDom = UpdateDOM (frameNumber frame) (evtClientFrame <$> stepedBy) diff
+          sendTextData conn $ A.encode $ updateDom
+          frameLoop' v
+        Right result ->
+          pure $ either Just (const Nothing) result
+      where
+        getNewerFrame = do
+          v@(f, _) <- readTVar (ctxFrame ctx)
+          check $ frameNumber f > frameNumber prevFrame
+          s <- readTMVar prevStepedBy  -- This should not block if we implement propertly. See `Context`'s documenation.
+          pure (v, s)
+
+    eventLoop :: IO Void
+    eventLoop = forever $ do
+      ev' <- A.decode <$> receiveData conn
+      ev  <- maybe (throwIO IllformedData) pure ev'
+      atomically $ writeTQueue (ctxEventQueue ctx) ev
+
+----------------------------------------------------------------------------
+
+-- | Context
+--
+--  * For every frame, its corresponding TMVar should get a value before the next (frame,stepedBy) is written.
+--  * Only exception to this is when exception occurs, last setted frame's `stepedBy` could be empty forever.
+--
+-- TODO: TMVar in a TVar. Is that a good idea?
+-- TODO: name `Context` doesn't sound good.. rename
+data Context = Context
+  { ctxFrame      :: TVar (Frame, TMVar (Maybe Event))
+  , ctxEventQueue :: TQueue Event   -- TBqueue might be better
+  , ctxThread     :: Async ()
+  }
+
+startContext
+  :: (st -> IO (Maybe (V.HTML, st, Event -> Maybe (IO ()))))
+  -> (V.HTML, st, Event -> Maybe (IO ()))
+  -> IO Context
+startContext step (vdom, st, fire) = do
+  let frame0 = Frame 0 vdom (const $ Just $ pure ())
+  let frame1 = Frame 1 vdom fire
+  (fv, qv) <- atomically $ do
+    r <- newTMVar Nothing
+    f <- newTVar (frame0, r)
+    q <- newTQueue
+    pure (f, q)
+  th <- async $ withWorker
+    (fireLoop (getNewFrame fv) (getEvent qv))
+    (stepLoop (setNewFrame fv) step st frame1)
+  pure $ Context fv qv th
+  where
+    setNewFrame var f = atomically $ do
+      r <- newEmptyTMVar
+      writeTVar var (f,r)
+      pure r
+
+    getNewFrame var = do
+      v@(_, r) <- readTVar var
+      bool retry (pure v) =<< isEmptyTMVar r
+
+    getEvent que = readTQueue que
 
 stepLoop
   :: (Frame -> IO (TMVar (Maybe Event)))
@@ -208,6 +317,7 @@ stepLoop setNewFrame step st frame = do
       stepLoop setNewFrame step newSt newFrame
 
 -- (1) STM's (<|>) は左偏があることに注意。
+--   どちらを左にしても event lost は防げない...
 -- (2) 上記の (<|>) の左偏により stepedBy は既に入っている可能性がある
 fireLoop
   :: STM (Frame, TMVar (Maybe Event))
@@ -226,10 +336,12 @@ fireLoop getNewFrame getEvent = forever $ do
           Right _ -> pure $ pure ()
   join act
 
--- Like `withAsync`, but it also stops the second action when
--- first actions ends with exception.
-withAsync' :: IO () -> IO a -> IO a
-withAsync' w m = withAsync w (\a -> link a *> m)
-
-whenJust_ :: Applicative m => Maybe a -> (a -> m ()) -> m ()
-whenJust_ m f = void $ traverse f m
+-- | Runs a worker action alongside the provided continuation.
+-- The worker will be automatically torn down when the continuation
+-- terminates.
+withWorker
+  :: IO Void -- ^ Worker to run
+  -> IO a
+  -> IO a
+withWorker worker cont =
+  either absurd id <$> race worker cont

--- a/src/Network/Wai/Handler/Replica.hs
+++ b/src/Network/Wai/Handler/Replica.hs
@@ -118,22 +118,6 @@ data Frame = Frame
   , frameFire :: Event -> Maybe (IO ())
   }
 
--- More clear version
--- change
---
---    * We should distinguish *frame* and *frame ID*.
---    * Excluding the *first step* from loop. We'll need to do this for SSR(server-side rendering)
---    * Two thread commnicating throw two tvar, its kinad hard to reason about and making
---      it hard to understand the flow.
---      We only need concurency while `running` function (2) part, so changed only that
---      part runs concurrently.
---    * changed the loop to make showing the vdom first. I think this is more easy to reason.
---
--- minor changes
---
---    * whenJust
---    *
---
 firstStep
   :: st
   -> (st -> IO (Maybe (V.HTML, st, Event -> Maybe (IO ()))))
@@ -200,8 +184,6 @@ attachContextToWebsocket conn ctx = withWorker eventLoop frameLoop
       ev' <- A.decode <$> receiveData conn
       ev  <- maybe (throwIO IllformedData) pure ev'
       atomically $ writeTQueue (ctxEventQueue ctx) ev
-
-----------------------------------------------------------------------------
 
 -- | Context
 --

--- a/src/Network/Wai/Handler/Replica.hs
+++ b/src/Network/Wai/Handler/Replica.hs
@@ -116,9 +116,9 @@ instance Exception ContextError
 --
 -- This function will block until:
 --
---   1) Connection/Protocol-wise exception thrown
---   2) Context ends gracefully, returning `Nothing`
---   3) Context ends by exception, returning `Just SomeException`
+--   * Connection/Protocol-wise exception thrown, or
+--   * Context ends gracefully, returning `Nothing`, or
+--   * Context ends by exception, returning `Just SomeException`
 --
 -- Some notes:
 --


### PR DESCRIPTION
This is still WIP. But since its kinda working already, I guess I'll make a PR for early feedback.
The sematic should be same as current `master` code. So current code should work.
The main changes are:  

 * Treat first step execution special. This is for SSR(server-side rendering)
 * Isolate the main steping loop context(I'm calling it `Context`. Needs a better name) from connection, so we can re-attach conection. This is for re-connecting.

Any feedback is welcome!