### PR TITLE
Support custom wai middleware

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -33,6 +33,7 @@ dependencies:
 - wai
 - websockets
 - wai-websockets
+- wai-middleware-static
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -33,7 +33,6 @@ dependencies:
 - wai
 - websockets
 - wai-websockets
-- wai-middleware-static
 
 library:
   source-dirs: src

--- a/replica.cabal
+++ b/replica.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 517e2f114ed80596196f03e88231f47e6e4212d5186908254731ee72999677c1
+-- hash: 934c3c818dc54dc66c2f0d09adbc567a3dfdf1eb37bee17e74f6c89b5d672e8c
 
 name:           replica
 version:        0.1.0.0
@@ -51,7 +51,6 @@ library
     , template-haskell
     , text
     , wai
-    , wai-middleware-static
     , wai-websockets
     , websockets
   default-language: Haskell2010
@@ -79,7 +78,6 @@ test-suite replica-test
     , template-haskell
     , text
     , wai
-    , wai-middleware-static
     , wai-websockets
     , websockets
   default-language: Haskell2010

--- a/replica.cabal
+++ b/replica.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.1.
+-- This file has been generated from package.yaml by hpack version 0.31.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 934c3c818dc54dc66c2f0d09adbc567a3dfdf1eb37bee17e74f6c89b5d672e8c
+-- hash: 517e2f114ed80596196f03e88231f47e6e4212d5186908254731ee72999677c1
 
 name:           replica
 version:        0.1.0.0
@@ -51,6 +51,7 @@ library
     , template-haskell
     , text
     , wai
+    , wai-middleware-static
     , wai-websockets
     , websockets
   default-language: Haskell2010
@@ -78,6 +79,7 @@ test-suite replica-test
     , template-haskell
     , text
     , wai
+    , wai-middleware-static
     , wai-websockets
     , websockets
   default-language: Haskell2010

--- a/src/Network/Wai/Handler/Replica.hs
+++ b/src/Network/Wai/Handler/Replica.hs
@@ -138,6 +138,3 @@ websocketApp initial step pendingConn = do
           atomically $ writeTVar chan (Just fire)
 
           go conn chan cf (Just newDom) next (serverFrame + 1)
-
-emptyMiddleware :: Middleware
-emptyMiddleware = id

--- a/src/Network/Wai/Handler/Replica.hs
+++ b/src/Network/Wai/Handler/Replica.hs
@@ -22,8 +22,6 @@ import           Network.WebSockets             (ServerApp)
 import           Network.WebSockets.Connection  (ConnectionOptions, Connection, acceptRequest, forkPingThread, receiveData, sendTextData, sendClose, sendCloseCode)
 import           Network.Wai                    (Application, Middleware, responseLBS)
 import           Network.Wai.Handler.WebSockets (websocketsOr)
-import qualified Network.Wai.Middleware.Static as MwS
-import           Network.Wai.Middleware.Static ((>->))
 
 import qualified Replica.VDOM                   as V
 import qualified Replica.VDOM.Render            as R
@@ -141,5 +139,5 @@ websocketApp initial step pendingConn = do
 
           go conn chan cf (Just newDom) next (serverFrame + 1)
 
-defaultMiddleware :: Middleware
-defaultMiddleware = MwS.staticPolicy (MwS.noDots >-> MwS.addBase "static") 
+emptyMiddleware :: Middleware
+emptyMiddleware = id


### PR DESCRIPTION
- Allow the user to supply custom WAI middleware
- `defaultMiddleware` gives users an easy way to load static assets from
a directory named `static`

Concur-replica PR to support this is at: https://github.com/pkamenarsky/concur-replica/pull/4