### PR TITLE
Add wss; fix protocol string

### DIFF
--- a/js/client.ts
+++ b/js/client.ts
@@ -402,8 +402,9 @@ const CLOSE_CODE_INTERNAL_ERROR = 1011
 function connect() {
   let root = document.createElement('div');
 
-  const port = window.location.port ? window.location.port : (window.location.protocol === 'http' ? 80 : 443);
-  const ws = new WebSocket("ws://" + window.location.hostname + ":" + port);
+  const port = window.location.port ? window.location.port : (window.location.protocol === 'http:' ? 80 : 443);
+  const wsProtocol = window.location.protocol === 'http:' ? 'ws:' : 'wss:';
+  const ws = new WebSocket(wsProtocol + "//" + window.location.hostname + ":" + port);
 
   document.body.appendChild(root);
 

--- a/js/dist/client.js
+++ b/js/dist/client.js
@@ -265,8 +265,9 @@ const CLOSE_CODE_NORMAL_CLOSURE = 1000;
 const CLOSE_CODE_INTERNAL_ERROR = 1011;
 function connect() {
     let root = document.createElement('div');
-    const port = window.location.port ? window.location.port : (window.location.protocol === 'http' ? 80 : 443);
-    const ws = new WebSocket("ws://" + window.location.hostname + ":" + port);
+    const port = window.location.port ? window.location.port : (window.location.protocol === 'http:' ? 80 : 443);
+    const wsProtocol = window.location.protocol === 'http:' ? 'ws:' : 'wss:';
+    const ws = new WebSocket(wsProtocol + "//" + window.location.hostname + ":" + port);
     document.body.appendChild(root);
     window['callCallback'] = (cbId, arg) => {
         const msg = {


### PR DESCRIPTION
This fixes the `window.location.protocol` matching by adding a trailing colon to the `'http'` string. `wss://` protocol is also used in place of `ws://` if `https` is used.